### PR TITLE
Fix #49: Improve memory requirements of containers

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,13 @@
+# Java options
+POWERAUTH_JAVA_OPTS=-XX:+UseG1GC -XX:+UseStringDeduplication
+
+# Memory settings
+POWERAUTH_SERVER_MEMORY_LIMIT=800m
+PUSH_SERVER_MEMORY_LIMIT=750m
+NEXTSTEP_MEMORY_LIMIT=700m
+WEBFLOW_MEMORY_LIMIT=800m
+DATA_ADAPTER_MEMORY_LIMIT=700m
+
 # Configuration for MySQL database related to PowerAuth Server
 POWERAUTH_MYSQL_PATH=/var/lib/powerauth/mysql
 POWERAUTH_MYSQL_PASSWORD=root

--- a/docker-compose-pa-all.yml
+++ b/docker-compose-pa-all.yml
@@ -55,6 +55,7 @@ services:
         container_name: powerauth-server
         ports:
             - "20010:8080"
+        mem_limit: ${POWERAUTH_SERVER_MEMORY_LIMIT}
         healthcheck:
             test: ["CMD", "curl", "-f", "http://localhost:8080/powerauth-java-server"]
             interval: 10s
@@ -100,6 +101,7 @@ services:
             - POWERAUTH_ADMIN_APPLICATION_DISPLAY_NAME=${POWERAUTH_ADMIN_APPLICATION_DISPLAY_NAME}
             - POWERAUTH_ADMIN_APPLICATION_ENVIRONMENT=${POWERAUTH_ADMIN_APPLICATION_ENVIRONMENT}
             - POWERAUTH_ADMIN_LOGGING=${POWERAUTH_ADMIN_LOGGING}
+            - JAVA_OPTS=${POWERAUTH_JAVA_OPTS}
         depends_on:
             powerauth-mysql:
                 condition: service_healthy
@@ -110,6 +112,7 @@ services:
         container_name: powerauth-push-server
         ports:
             - "20030:8080"
+        mem_limit: ${PUSH_SERVER_MEMORY_LIMIT}
         healthcheck:
             test: ["CMD", "curl", "-f", "http://localhost:8080/powerauth-push-server"]
             interval: 10s
@@ -151,6 +154,7 @@ services:
             - PUSH_SERVER_APPLICATION_DISPLAY_NAME=${PUSH_SERVER_APPLICATION_DISPLAY_NAME}
             - PUSH_SERVER_APPLICATION_ENVIRONMENT=${PUSH_SERVER_APPLICATION_ENVIRONMENT}
             - PUSH_SERVER_LOGGING=${PUSH_SERVER_LOGGING}
+            - JAVA_OPTS=${POWERAUTH_JAVA_OPTS}
         depends_on:
             powerauth-push-mysql:
                 condition: service_healthy
@@ -163,6 +167,7 @@ services:
         container_name: powerauth-nextstep
         ports:
             - "13010:8080"
+        mem_limit: ${NEXTSTEP_MEMORY_LIMIT}
         healthcheck:
             test: ["CMD", "curl", "-f", "http://localhost:8080/powerauth-nextstep"]
             interval: 10s
@@ -185,6 +190,7 @@ services:
             - NEXTSTEP_APPLICATION_DISPLAY_NAME=${NEXTSTEP_APPLICATION_DISPLAY_NAME}
             - NEXTSTEP_APPLICATION_ENVIRONMENT=${NEXTSTEP_APPLICATION_ENVIRONMENT}
             - NEXTSTEP_LOGGING=${NEXTSTEP_LOGGING}
+            - JAVA_OPTS=${POWERAUTH_JAVA_OPTS}
         depends_on:
             powerauth-webflow-mysql:
                 condition: service_healthy
@@ -195,6 +201,7 @@ services:
         container_name: powerauth-data-adapter
         ports:
             - "13050:8080"
+        mem_limit: ${DATA_ADAPTER_MEMORY_LIMIT}
         healthcheck:
             test: ["CMD", "curl", "-f", "http://localhost:8080/powerauth-data-adapter"]
             interval: 10s
@@ -218,6 +225,7 @@ services:
             - DATA_ADAPTER_APPLICATION_DISPLAY_NAME=${DATA_ADAPTER_APPLICATION_DISPLAY_NAME}
             - DATA_ADAPTER_APPLICATION_ENVIRONMENT=${DATA_ADAPTER_APPLICATION_ENVIRONMENT}
             - DATA_ADAPTER_LOGGING=${DATA_ADAPTER_LOGGING}
+            - JAVA_OPTS=${POWERAUTH_JAVA_OPTS}
         depends_on:
             powerauth-webflow-mysql:
                 condition: service_healthy
@@ -228,6 +236,7 @@ services:
         container_name: powerauth-webflow
         ports:
             - "13030:8080"
+        mem_limit: ${WEBFLOW_MEMORY_LIMIT}
         healthcheck:
             test: ["CMD", "curl", "-f", "http://localhost:8080/powerauth-webflow"]
             interval: 10s
@@ -260,6 +269,7 @@ services:
             - WEBFLOW_APPLICATION_DISPLAY_NAME=${WEBFLOW_APPLICATION_DISPLAY_NAME}
             - WEBFLOW_APPLICATION_ENVIRONMENT=${WEBFLOW_APPLICATION_ENVIRONMENT}
             - WEBFLOW_LOGGING=${WEBFLOW_LOGGING}
+            - JAVA_OPTS=${POWERAUTH_JAVA_OPTS}
         depends_on:
             powerauth-webflow-mysql:
                 condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
         container_name: powerauth-server
         ports:
             - "20010:8080"
+        mem_limit: ${POWERAUTH_SERVER_MEMORY_LIMIT}
         healthcheck:
             test: ["CMD", "curl", "-f", "http://localhost:8080/powerauth-java-server"]
             interval: 10s
@@ -84,6 +85,7 @@ services:
             - POWERAUTH_ADMIN_APPLICATION_DISPLAY_NAME=${POWERAUTH_ADMIN_APPLICATION_DISPLAY_NAME}
             - POWERAUTH_ADMIN_APPLICATION_ENVIRONMENT=${POWERAUTH_ADMIN_APPLICATION_ENVIRONMENT}
             - POWERAUTH_ADMIN_LOGGING=${POWERAUTH_ADMIN_LOGGING}
+            - JAVA_OPTS=${POWERAUTH_JAVA_OPTS}
         depends_on:
             powerauth-mysql:
                 condition: service_healthy
@@ -94,6 +96,7 @@ services:
         container_name: powerauth-push-server
         ports:
             - "20030:8080"
+        mem_limit: ${PUSH_SERVER_MEMORY_LIMIT}
         healthcheck:
             test: ["CMD", "curl", "-f", "http://localhost:8080/powerauth-push-server"]
             interval: 10s
@@ -135,6 +138,7 @@ services:
             - PUSH_SERVER_APPLICATION_DISPLAY_NAME=${PUSH_SERVER_APPLICATION_DISPLAY_NAME}
             - PUSH_SERVER_APPLICATION_ENVIRONMENT=${PUSH_SERVER_APPLICATION_ENVIRONMENT}
             - PUSH_SERVER_LOGGING=${PUSH_SERVER_LOGGING}
+            - JAVA_OPTS=${POWERAUTH_JAVA_OPTS}
         depends_on:
             powerauth-push-mysql:
                 condition: service_healthy


### PR DESCRIPTION
We didn't have any crashes or issues with `G1GC` and String deduplication so far, so I suggest we enable these settings by default and limit memory usage for Docker. These settings can be easily overriden using `.env` file.