### PR TITLE
Fix #138: Rename Docker images for Apple Silicon

### DIFF
--- a/build-arm64v8.sh
+++ b/build-arm64v8.sh
@@ -22,11 +22,11 @@ docker build -t powerauth/push-postgresql:$TAG -t powerauth/push-postgresql:late
 docker build -t powerauth/webflow-postgresql:$TAG -t powerauth/webflow-postgresql:latest -f docker-powerauth-webflow-postgresql/Dockerfile .
 
 ## Build Application Images
-docker build -t powerauth/server/arm64v8:$TAG -t powerauth/server/arm64v8:latest -f arm64v8/docker-powerauth-server/Dockerfile .
-docker build -t powerauth/push-server/arm64v8:$TAG -t powerauth/push-server/arm64v8:latest -f arm64v8/docker-powerauth-push-server/Dockerfile .
-docker build -t powerauth/nextstep/arm64v8:$TAG -t powerauth/nextstep/arm64v8:latest -f arm64v8/docker-powerauth-nextstep/Dockerfile .
-docker build -t powerauth/data-adapter/arm64v8:$TAG -t powerauth/data-adapter/arm64v8:latest -f arm64v8/docker-powerauth-data-adapter/Dockerfile .
-docker build -t powerauth/webflow/arm64v8:$TAG -t powerauth/webflow/arm64v8:latest -f arm64v8/docker-powerauth-webflow/Dockerfile .
-docker build -t powerauth/tpp-engine/arm64v8:$TAG -t powerauth/tpp-engine/arm64v8:latest -f arm64v8/docker-powerauth-tpp-engine/Dockerfile .
+docker build -t powerauth/server-arm64v8:$TAG -t powerauth/server-arm64v8:latest -f arm64v8/docker-powerauth-server/Dockerfile .
+docker build -t powerauth/push-server-arm64v8:$TAG -t powerauth/push-server-arm64v8:latest -f arm64v8/docker-powerauth-push-server/Dockerfile .
+docker build -t powerauth/nextstep-arm64v8:$TAG -t powerauth/nextstep-arm64v8:latest -f arm64v8/docker-powerauth-nextstep/Dockerfile .
+docker build -t powerauth/data-adapter-arm64v8:$TAG -t powerauth/data-adapter-arm64v8:latest -f arm64v8/docker-powerauth-data-adapter/Dockerfile .
+docker build -t powerauth/webflow-arm64v8:$TAG -t powerauth/webflow-arm64v8:latest -f arm64v8/docker-powerauth-webflow/Dockerfile .
+docker build -t powerauth/tpp-engine-arm64v8:$TAG -t powerauth/tpp-engine-arm64v8:latest -f arm64v8/docker-powerauth-tpp-engine/Dockerfile .
 
 echo "TAG: $TAG"

--- a/docker-compose-arm64v8.yml
+++ b/docker-compose-arm64v8.yml
@@ -35,7 +35,7 @@ services:
 
     # PowerAuth Server
     powerauth-java-server:
-        image: powerauth/server/arm64v8
+        image: powerauth/server-arm64v8
         container_name: powerauth-server
         ports:
             - "20010:8080"
@@ -102,7 +102,7 @@ services:
 
     # PowerAuth Push Server
     powerauth-push-server:
-        image: powerauth/push-server/arm64v8
+        image: powerauth/push-server-arm64v8
         container_name: powerauth-push-server
         ports:
             - "20030:8080"

--- a/docker-compose-pa-all-arm64v8.yml
+++ b/docker-compose-pa-all-arm64v8.yml
@@ -51,7 +51,7 @@ services:
 
     # PowerAuth Server
     powerauth-java-server:
-        image: powerauth/server/arm64v8
+        image: powerauth/server-arm64v8
         container_name: powerauth-server
         ports:
             - "20010:8080"
@@ -118,7 +118,7 @@ services:
 
     # PowerAuth Push Server
     powerauth-push-server:
-        image: powerauth/push-server/arm64v8
+        image: powerauth/push-server-arm64v8
         container_name: powerauth-push-server
         ports:
             - "20030:8080"
@@ -180,7 +180,7 @@ services:
 
     # PowerAuth NextStep Server
     powerauth-nextstep:
-        image: powerauth/nextstep/arm64v8
+        image: powerauth/nextstep-arm64v8
         container_name: powerauth-nextstep
         ports:
             - "13010:8080"
@@ -223,7 +223,7 @@ services:
 
     # PowerAuth TPP registry and consent engine
     powerauth-tpp-engine:
-        image: powerauth/tpp-engine/arm64v8
+        image: powerauth/tpp-engine-arm64v8
         container_name: powerauth-tpp-engine
         ports:
             - "13060:8080"
@@ -257,7 +257,7 @@ services:
 
     # PowerAuth Data Adapter
     powerauth-data-adapter:
-        image: powerauth/data-adapter/arm64v8
+        image: powerauth/data-adapter-arm64v8
         container_name: powerauth-data-adapter
         ports:
             - "13050:8080"
@@ -293,7 +293,7 @@ services:
 
     # PowerAuth Web Flow Server
     powerauth-webflow:
-        image: powerauth/webflow/arm64v8
+        image: powerauth/webflow-arm64v8
         container_name: powerauth-webflow
         ports:
             - "13030:8080"

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -47,7 +47,7 @@ docker pull powerauth/tpp-engine
 docker pull powerauth/webflow-postgresql
 ```
 
-_Note: Use the `/arm64v8` suffix for downloading Docker images for the Apple Silicon CPU architecture._
+_Note: Use the `-arm64v8` suffix for downloading Docker images for the Apple Silicon CPU architecture._
 
 #### Basic Installation
 
@@ -58,7 +58,7 @@ docker pull powerauth/server-postgresql
 docker pull powerauth/push-postgresql
 ```
 
-_Note: Use the `/arm64v8` suffix for downloading Docker images for the Apple Silicon CPU architecture._
+_Note: Use the `-arm64v8` suffix for downloading Docker images for the Apple Silicon CPU architecture._
 
 ### 3. Configure Docker Images
 

--- a/docs/Hardware-Requirements.md
+++ b/docs/Hardware-Requirements.md
@@ -8,7 +8,7 @@ Following hardware platforms are supported by PowerAuth Docker images:
 - amd64 (also known as x86_64)
 - s390x
 - ppc64le
-- arm64v8 (use the `/arm64v8` suffix for Docker images, use `build-arm64v8.sh` script for building, and use the `-arm64v8.yml` suffix for docker-compose)
+- arm64v8 (use the `-arm64v8` suffix for Docker images, use `build-arm64v8.sh` script for building, and use the `-arm64v8.yml` suffix for docker-compose)
 
 ## Hardware Requirements of Basic Docker Images for PowerAuth Server and Push Server
 


### PR DESCRIPTION
Unfortuntely the original image names with `/` character in the name are not supported by Docker Hub, so I had to rename the images.